### PR TITLE
Feat: `eslintTsconfig.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test-manual/tsconfig.json
 test-manual/tsconfigCjs.json
 test-manual/tsconfigEsm.json
 test-manual/test
+test-manual/eslintTsconfig.json
 test-tmp
 
 # Logs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   '@types/prompts': ^2.0.11
   '@types/semver': ^7.3.6
   '@typescript-eslint/eslint-plugin': ^4.23.0
+  ansi-parser: ^3.2.10
   axios: ^0.21.1
   commander: ^7.2.0
   concat-stream: ^2.0.0
@@ -76,6 +77,7 @@ devDependencies:
   '@types/prompts': 2.0.11
   '@types/semver': 7.3.6
   '@typescript-eslint/eslint-plugin': 4.23.0_eslint@7.26.0+typescript@4.3.2
+  ansi-parser: 3.2.10
   concat-stream: 2.0.0
   eslint: 7.26.0
   eslint-config-standard-with-typescript: 20.0.0_a94ec9da3f51b9f9ad707a396574bc74
@@ -1117,6 +1119,10 @@ packages:
       type-fest: 0.21.3
     dev: true
 
+  /ansi-parser/3.2.10:
+    resolution: {integrity: sha512-CGKGIbd678lm15IXJXI1cTyOVAnMQw0jES+klW/yIc+GzYccsYanLMhczPIIj2hE64B79g75QfiuWrEWd6nJdg==}
+    dev: true
+
   /ansi-regex/5.0.0:
     resolution: {integrity: sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==}
     engines: {node: '>=8'}
@@ -1177,7 +1183,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.18.0
+      es-abstract: 1.18.3
     dev: true
 
   /astral-regex/2.0.0:
@@ -1616,6 +1622,28 @@ packages:
 
   /es-abstract/1.18.0:
     resolution: {integrity: sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      es-to-primitive: 1.2.1
+      function-bind: 1.1.1
+      get-intrinsic: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.2
+      is-callable: 1.2.3
+      is-negative-zero: 2.0.1
+      is-regex: 1.1.3
+      is-string: 1.0.6
+      object-inspect: 1.10.3
+      object-keys: 1.1.1
+      object.assign: 4.1.2
+      string.prototype.trimend: 1.0.4
+      string.prototype.trimstart: 1.0.4
+      unbox-primitive: 1.0.1
+    dev: true
+
+  /es-abstract/1.18.3:
+    resolution: {integrity: sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -3389,8 +3417,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /path-parse/1.0.6:
-    resolution: {integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==}
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
   /path-type/3.0.0:
@@ -3580,7 +3608,7 @@ packages:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
     dependencies:
       is-core-module: 2.4.0
-      path-parse: 1.0.6
+      path-parse: 1.0.7
     dev: true
 
   /reusify/1.0.4:
@@ -4171,6 +4199,11 @@ packages:
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  /yargs-parser/20.2.4:
+    resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /yargs-parser/20.2.7:
     resolution: {integrity: sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==}
     engines: {node: '>=10'}
@@ -4186,5 +4219,5 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.2
       y18n: 5.0.8
-      yargs-parser: 20.2.7
+      yargs-parser: 20.2.4
     dev: true

--- a/res/standardConfig.json
+++ b/res/standardConfig.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/eslintrc",
-  "root": true,
-  "extends": "standard",
-  "ignorePatterns": "/dist"
-}

--- a/res/tsStandardConfig.json
+++ b/res/tsStandardConfig.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/eslintrc",
-  "root": true,
-  "extends": "standard-with-typescript",
-  "ignorePatterns": "/dist",
-  "parserOptions": {
-    "project": "./tsconfig.json"
-  }
-}

--- a/test-manual/test.sh
+++ b/test-manual/test.sh
@@ -11,5 +11,6 @@ rm -rf \
   tsconfig.json \
   tsconfigCjs.json \
   tsconfigEsm.json \
-  test
+  test \
+  eslintTsconfig.json
 node ../dist/index


### PR DESCRIPTION
Instead of `parserOptions.project` being `tsconfig.json`, it is `eslintTsconfig.json` in some scenarios. This is so that eslint will still work on files that don't need to be compiled by `tsc`. 

Fixes #7 