### PR TITLE
fix: Include must be an array

### DIFF
--- a/lib/helpers/create-tasks/create/standard.ts
+++ b/lib/helpers/create-tasks/create/standard.ts
@@ -39,7 +39,7 @@ const standard: Task<void, [CodeLint, PackageJsonEditor, boolean, Test]> = {
           : undefined
       }, { spaces: 2 }), ts && test === 'mocha' && writeFile(eslintTsconfigPath, {
         extends: './tsconfig.json',
-        include: '**/*.ts'
+        include: ['**/*.ts']
       }, { spaces: 2 }))
     }
   }


### PR DESCRIPTION
In the `eslintTsconfig.json` the include property is an array.